### PR TITLE
[MX-489] Obfuscates key values in generated Objective-C file

### DIFF
--- a/ios/ReactNativeConfig/BuildDotenvConfig.rb
+++ b/ios/ReactNativeConfig/BuildDotenvConfig.rb
@@ -60,11 +60,10 @@ objc_dict = indexed_keys.map.with_index do |obj, index|
 end
 
 template = <<~EOF
-  static NSDictionary *DOT_ENV;
-  
-  @interface ReactNativeConfigTrampoline: NSObject
-  @end
-  
+  #import "GeneratedDotEnv.h"
+
+  NSDictionary *DOT_ENV;
+
   @implementation ReactNativeConfigTrampoline
   
   + (void)load

--- a/ios/ReactNativeConfig/BuildDotenvConfig.rb
+++ b/ios/ReactNativeConfig/BuildDotenvConfig.rb
@@ -2,6 +2,9 @@
 # frozen_string_literal: true
 
 require_relative 'ReadDotEnv'
+require 'digest'
+require 'securerandom'
+require 'set'
 
 envs_root = ARGV[0]
 m_output_path = ARGV[1]
@@ -15,10 +18,65 @@ Encoding.default_internal = Encoding::UTF_8
 dotenv, custom_env = read_dot_env(envs_root)
 puts "read dotenv #{dotenv}"
 
-# create obj file that sets DOT_ENV as a NSDictionary
-dotenv_objc = dotenv.map { |k, v| %(@"#{k}":@"#{v.chomp}") }.join(',')
-template = <<EOF
-  #define DOT_ENV @{ #{dotenv_objc} };
+# create objc file with obfuscated keys, unobfuscated at runtime.
+# Implementation inspired from cocoapods-keys: https://github.com/orta/cocoapods-keys/blob/4153cfc7621a89c7ae3f96bb0285d9602f41e267/lib/key_master.rb
+data_length = dotenv.values.map(&:length).reduce(0, :+) * rand(20..29)
+data = SecureRandom.base64(data_length)
+data += '\\"' # this is a sentinel for keys that contain literal quote characters
+
+used_indexes = Set.new
+indexed_keys = {}
+dotenv.each do |key, escaped_value|
+  indexed_keys[key] = []
+  # ReadDotEnv.rb escapes these, but we need to unescape them for use with obfuscation
+  value = escaped_value.gsub('\"', '"')
+  value.chars.each_with_index do |char, char_index|
+    loop do # we loop until we break to avoid index collisions
+      if char == '"'
+        index = data.length - 1 # point to the sentinel for quote characters
+        indexed_keys[key][char_index] = index
+        break
+      else
+        index = SecureRandom.random_number data.length
+        unless used_indexes.include?(index)
+          data[index] = char # store this character of the key in the obfuscated data
+          indexed_keys[key][char_index] = index # point to the index in data
+          used_indexes << index # mark the index in data as already in-use
+          break
+        end
+      end
+    end
+  end
+end
+
+c_strings = indexed_keys.map.with_index do |obj, index|
+  _key, value = obj
+  data_indexes = value.map { |i| "[data characterAtIndex:#{i}]" }
+  "char string#{index}[#{value.length + 1}] = {#{data_indexes.join(', ')}, '\\0'};"
+end
+objc_dict = indexed_keys.map.with_index do |obj, index|
+  key, _value = obj
+  "@\"#{key}\": [NSString stringWithCString:string#{index} encoding:NSUTF8StringEncoding]"
+end
+
+template = <<~EOF
+  static NSDictionary *DOT_ENV;
+  
+  @interface ReactNativeConfigTrampoline: NSObject
+  @end
+  
+  @implementation ReactNativeConfigTrampoline
+  
+  + (void)load
+  {
+    NSString *data = @"#{data.gsub('\\', '\\\\\\').gsub('"', '\\"')}";
+    #{c_strings.join("\n  ")}
+    DOT_ENV = @{
+      #{objc_dict.join(", \n    ")}
+    };
+  }
+  
+  @end
 EOF
 
 # write it so that ReactNativeConfig.m can return it

--- a/ios/ReactNativeConfig/GeneratedDotEnv.h
+++ b/ios/ReactNativeConfig/GeneratedDotEnv.h
@@ -1,0 +1,6 @@
+@import Foundation;
+
+extern const NSDictionary *DOT_ENV;
+
+@interface ReactNativeConfigTrampoline: NSObject
+@end

--- a/ios/ReactNativeConfig/ReactNativeConfig.m
+++ b/ios/ReactNativeConfig/ReactNativeConfig.m
@@ -1,5 +1,5 @@
 #import "ReactNativeConfig.h"
-#import "GeneratedDotEnv.m" // written during build by BuildDotenvConfig.ruby
+#import "GeneratedDotEnv.h" // .m is written during build by BuildDotenvConfig.ruby
 
 @implementation ReactNativeConfig
 


### PR DESCRIPTION
I stole this implementation from `cocoapods-keys`, and I learned a lot from it.

Here's an example `.env` file:

```
TESTING_KEY=testing_value
TESTING_KEY2=testing_value
TESTING_KEY3=testing_"value"
```

And here's the generated Objective-C:

```objc
#import "GeneratedDotEnv.h"

NSDictionary *DOT_ENV;

@implementation ReactNativeConfigTrampoline

+ (void)load
{
  NSString *data = @"dwCTZI9KOais5pT3KlFzsLokuagreTGDCKe7yVHpJHetQPaGAnsvmmLU3rdNopKrfS7V1K7k2jyY2YtB/l6vD+8wAO09aC8u1STnPUnD9hE2aRiTwxnVK5OByRvCbpOqKeCleu0MtcZEvMvS89PUcm6jdpQwKDnfrWrNCAYOFjU+yVdbIpVGxsiKpsM7yTf27MON/j8lJZAkIZWXE4fnn9X5pAD0B5dxXNpKjGyVFu50sAfgn/Vfo3ly6qpA8G/yYLeEX8d83Yd0exG8qVsmvtQ5zvJCUoRDbiv6twPbJ0+mub+74AwLsjJdMLWOXUYGk2fSPK655nAjL1PqU6JfEBuV/eI0xmnfTJ+fFvjhgOnqt2BM9C6Gkj13VravbZxsTWZZhPYC5iqjJ8ZuW1FULEitwzk+QOslCrOT08npOY2lVqhG3X00Z10jGUtB4baotiQjYdFZ7aqs6pr3w1dwUasaGCCRCi0ZvoDEmWtVigPRK9HfoDiXvBcQV0U3j3N03qdFucJmMia9tyQ3zMced05EDY5Ff/fkZFexUk+xGxB6cFVZmK886HrwC9wknE67oWGjCBMzz5nxENSeassCNYdz0ux9rBGtl/wJi5r38qsYFKJiM7ptQUCodGWvJjniaZ82Bkfk+dXusgP+aIdeI3KL0K70bjcHE48aatPrtYIDRqAtDw4OL49+Vgv+ASa5sbPfIHIHHH5ZV4MDuxGE0s2n8O1UlxTmAPghDQpu2msq8w9WawVaayx1aaG26NYi98ne5ZrlXzKQiinTfjHVGIVrg8+8howCjWhaOym4en6lnCudhcJLu+pcmIHg40tn4wc8NC2R28tTh6iO+iBU8RvaBed81vU5qCBxfkOc5Hu0g2cepzIgv/+30lD5CRNjXliBlrqeK49qfu3LQeZSiTv6f1KpMu9ZVucyinh29sDN8LjpxGWWf+kaGUlOuZijq3YEOPgZbJbuFZr/EhGQTgYkFw95P72MrzYFQoAJAo3vruFThNCq2KU/ltPr2cwHvNigbuv1BeXtOnEPwwUPj8r4Ym9Lp/V_+Gz5t/KApWGBY0TYud8OCaKboRD46DOxf/TSFSYdgCLrkeK/MTQIzUTywX1wkk94XFDMeqRExueWPElKAPIJhy3TUjApVoqU42eUjqep2x21fbLhdSeBDUtp7G+IqPwfbS1QFUZnTZFTXdBw3giFgLF/+sKr/ZGt56eF/sWJ0O001GQirc8f9lYrYz+Fs3km5khvvJrOfeoYvgE1tFeGR2i4ySpUasMM8w4YHr_7QlT6J//LMSa54lmRXliG_WBUQDId7I3JVMVyA9Qd+l73Ffj141rUiP0rhcn/HixcyM4SvomLJXw3jjp93PTDicUS\\\"";
  char string0[14] = {[data characterAtIndex:136], [data characterAtIndex:808], [data characterAtIndex:274], [data characterAtIndex:442], [data characterAtIndex:1270], [data characterAtIndex:831], [data characterAtIndex:653], [data characterAtIndex:1308], [data characterAtIndex:1260], [data characterAtIndex:471], [data characterAtIndex:900], [data characterAtIndex:342], [data characterAtIndex:659], '\0'};
  char string1[14] = {[data characterAtIndex:78], [data characterAtIndex:1257], [data characterAtIndex:618], [data characterAtIndex:627], [data characterAtIndex:1340], [data characterAtIndex:362], [data characterAtIndex:1096], [data characterAtIndex:1286], [data characterAtIndex:854], [data characterAtIndex:675], [data characterAtIndex:427], [data characterAtIndex:874], [data characterAtIndex:1266], '\0'};
  char string2[16] = {[data characterAtIndex:43], [data characterAtIndex:34], [data characterAtIndex:594], [data characterAtIndex:1060], [data characterAtIndex:110], [data characterAtIndex:572], [data characterAtIndex:827], [data characterAtIndex:1055], [data characterAtIndex:1377], [data characterAtIndex:918], [data characterAtIndex:108], [data characterAtIndex:17], [data characterAtIndex:820], [data characterAtIndex:857], [data characterAtIndex:1377], '\0'};
  DOT_ENV = @{
    @"TESTING_KEY": [NSString stringWithCString:string0 encoding:NSUTF8StringEncoding], 
    @"TESTING_KEY2": [NSString stringWithCString:string1 encoding:NSUTF8StringEncoding], 
    @"TESTING_KEY3": [NSString stringWithCString:string2 encoding:NSUTF8StringEncoding]
  };
}

@end
``` 

This gets generated on every Xcode build, but in testing it didn't take that long (and means that `.env` changes get applied more often than `pod install`). 

When I run `NSLog(@"%@", [ReactNativeConfig env]);`, I get this:

```
{
    "TESTING_KEY" = "testing_value";
    "TESTING_KEY2" = "testing_value";
    "TESTING_KEY3" = "testing_\"value\"";
}
```

And I manually verified that keys work the same with quotation marks.

Next steps once this is merged is to migrate Eigen to use it, then verify everything works there. Once we're confident this works in production, we can send a PR to the upstream repo.