### PR TITLE
Add env var hiding android

### DIFF
--- a/.github/workflows/windows-ci.yml
+++ b/.github/workflows/windows-ci.yml
@@ -16,7 +16,7 @@ jobs:
         node-version: '12.9.1'
 
     - name: Setup MSBuild
-      uses: microsoft/setup-msbuild@v1.0.0
+      uses: microsoft/setup-msbuild@v1.0.2
       with:
         vs-version: 16.5
 

--- a/.github/workflows/windows-ci.yml
+++ b/.github/workflows/windows-ci.yml
@@ -16,9 +16,7 @@ jobs:
         node-version: '12.9.1'
 
     - name: Setup MSBuild
-      uses: microsoft/setup-msbuild@v1.0.0
-      env:
-        ACTIONS_ALLOW_UNSECURE_COMMANDS: 'true'
+      uses: microsoft/setup-msbuild@v1.0.2
       with:
         vs-version: 16.5
 

--- a/.github/workflows/windows-ci.yml
+++ b/.github/workflows/windows-ci.yml
@@ -16,7 +16,9 @@ jobs:
         node-version: '12.9.1'
 
     - name: Setup MSBuild
-      uses: microsoft/setup-msbuild@v1.0.2
+      uses: microsoft/setup-msbuild@v1.0.0
+      env:
+        ACTIONS_ALLOW_UNSECURE_COMMANDS: 'true'
       with:
         vs-version: 16.5
 

--- a/Example/.env
+++ b/Example/.env
@@ -1,3 +1,2 @@
 ENV=dev
 API_URL=http://localhost
-EXAMPLE_KEY=thisisanartsyenvvar

--- a/Example/.env
+++ b/Example/.env
@@ -1,2 +1,3 @@
 ENV=dev
 API_URL=http://localhost
+EXAMPLE_KEY=thisisanartsyenvvar

--- a/Example/App.js
+++ b/Example/App.js
@@ -16,6 +16,7 @@ export default class App extends Component {
     return (
       <View style={styles.container}>
         <Text style={styles.text}>API_URL={Config.API_URL}</Text>
+        <Text style={styles.text}>EXAMPLE_KEY={Config.EXAMPLE_KEY}</Text>
       </View>
     );
   }

--- a/Example/App.js
+++ b/Example/App.js
@@ -16,7 +16,6 @@ export default class App extends Component {
     return (
       <View style={styles.container}>
         <Text style={styles.text}>API_URL={Config.API_URL}</Text>
-        <Text style={styles.text}>EXAMPLE_KEY={Config.EXAMPLE_KEY}</Text>
       </View>
     );
   }

--- a/Example/android/app/build.gradle
+++ b/Example/android/app/build.gradle
@@ -200,6 +200,7 @@ dependencies {
     implementation "com.facebook.react:react-native:+"  // From node_modules
 
     implementation "androidx.swiperefreshlayout:swiperefreshlayout:1.0.0"
+    testImplementation 'junit:junit:4.12'
 
     debugImplementation("com.facebook.flipper:flipper:${FLIPPER_VERSION}") {
       exclude group:'com.facebook.fbjni'

--- a/Example/android/app/src/main/java/com/example/ReactNativeConfigUtils.java
+++ b/Example/android/app/src/main/java/com/example/ReactNativeConfigUtils.java
@@ -1,0 +1,21 @@
+package com.example;
+
+import android.util.Base64;
+
+public class ReactNativeConfigUtils {
+    public static String decode(String encodedString, String key) {
+        byte[] decodedBytes = Base64.decode(encodedString, Base64.DEFAULT);
+        byte[] keyBytes = key.getBytes();
+
+        int len = decodedBytes.length;
+        int keyBytesLen = keyBytes.length;
+
+        byte[] resultBytes = new byte[len];
+
+        for (int i = 0; i < decodedBytes.length; i++) {
+            resultBytes[i] = (byte) (decodedBytes[i] ^ keyBytes[i % keyBytesLen]);
+        }
+
+        return new String(resultBytes);
+    }
+}

--- a/Example/android/app/src/test/java/android/util/Base64.java
+++ b/Example/android/app/src/test/java/android/util/Base64.java
@@ -1,0 +1,13 @@
+package android.util;
+
+public class Base64 {
+    public static String encodeToString(byte[] input, int flags) {
+        return java.util.Base64.getEncoder().encodeToString(input);
+    }
+
+    public static byte[] decode(String str, int flags) {
+        return java.util.Base64.getDecoder().decode(str);
+    }
+
+    public static int DEFAULT = 0;
+}

--- a/Example/android/app/src/test/java/com/example/ReactNativeConfigUtilsTest.java
+++ b/Example/android/app/src/test/java/com/example/ReactNativeConfigUtilsTest.java
@@ -1,0 +1,32 @@
+package com.example;
+
+import android.util.Base64;
+
+import junit.framework.TestCase;
+
+public class ReactNativeConfigUtilsTest extends TestCase {
+
+    public void testDecode() {
+        String unDecoded = BuildConfig.EXAMPLE_KEY;
+        String key = BuildConfig.XOR_KEY;
+
+        String decodedString = ReactNativeConfigUtils.decode(unDecoded, key);
+        String expected = "thisisanartsyenvvar";
+
+        assertEquals("Example Key is NOT correctly decoded", expected, decodedString);
+    }
+
+    /**
+     * Test that the encoded BuildConfig env vars are not just
+     * a simple base64 encoded strings
+     */
+    public void testEncodingIsNotSimpleBase64() {
+        String str = "thisisanartsyenvvar";
+        String envVar = BuildConfig.EXAMPLE_KEY;
+
+        String encodedWithBase64 = Base64.encodeToString(str.getBytes(), Base64.DEFAULT);
+
+        assertTrue("Ooops, The env vars are only base64 encoded", !envVar.equals(encodedWithBase64));
+
+    }
+}

--- a/Example/android/app/src/test/java/com/example/ReactNativeConfigUtilsTest.java
+++ b/Example/android/app/src/test/java/com/example/ReactNativeConfigUtilsTest.java
@@ -7,11 +7,11 @@ import junit.framework.TestCase;
 public class ReactNativeConfigUtilsTest extends TestCase {
 
     public void testDecode() {
-        String unDecoded = BuildConfig.EXAMPLE_KEY;
+        String unDecoded = BuildConfig.API_URL;
         String key = BuildConfig.XOR_KEY;
 
         String decodedString = ReactNativeConfigUtils.decode(unDecoded, key);
-        String expected = "thisisanartsyenvvar";
+        String expected = "http://localhost";
 
         assertEquals("Example Key is NOT correctly decoded", expected, decodedString);
     }
@@ -21,8 +21,8 @@ public class ReactNativeConfigUtilsTest extends TestCase {
      * a simple base64 encoded strings
      */
     public void testEncodingIsNotSimpleBase64() {
-        String str = "thisisanartsyenvvar";
-        String envVar = BuildConfig.EXAMPLE_KEY;
+        String str = "http://localhost";
+        String envVar = BuildConfig.API_URL;
 
         String encodedWithBase64 = Base64.encodeToString(str.getBytes(), Base64.DEFAULT);
 

--- a/android/dotenv.gradle
+++ b/android/dotenv.gradle
@@ -105,9 +105,23 @@ def encodeString(String str, String key) {
     return result.encodeBase64().toString()
 }
 
+def escapeEncodedKeys(List encodedKeys) {
+    def result = "{"
+    encodedKeys.eachWithIndex { it, i ->
+        if (i != encodedKeys.size()-1) {
+            result += "\"$it\","
+        } else {
+            result += "\"$it\""
+        }
+    }
+    result += "}"
+    return result
+}
+
 
 android {
     defaultConfig {
+        def encodedKeys = [] //needed to keep track of keys encoded
         String xorKey = generateKey(keyLength)
         project.env.each { k, v ->
             def escaped = v.replaceAll("%","\\\\u0025")
@@ -119,7 +133,13 @@ android {
 
             resValue "string", k, "\"$encodedEscaped\""
             resValue "string", "XOR_KEY", "\"$xorKey\""
+
+            encodedKeys << k
         }
+        //Add the encodedkeys to buildconfig. Needed to know which var to decode
+        def escapedKeys = escapeEncodedKeys(encodedKeys)
+        buildConfigField "String[]", "ENCODED_KEYS", escapedKeys
+
     }
 }
 
@@ -133,6 +153,7 @@ tasks.whenTaskAdded { task ->
                         if (envConfigName.contains(variantConfigString.toLowerCase())) {
                             loadDotEnv(envConfigName)
 
+                            def encodedKeys = [] //needed to keep track of keys encoded
                             String xorKey = generateKey(keyLength)
                             project.env.each { k, v ->
                                 def escaped = v.replaceAll("%","\\\\u0025")
@@ -145,7 +166,12 @@ tasks.whenTaskAdded { task ->
 
                                 variant.resValue "string", k, "\"$encodedEscaped\""
                                 variant.resValue "string", "XOR_KEY", "\"$xorKey\""
+
+                                encodedKeys << k
                             }
+                            //Add the encodedkeys to buildconfig. Needed to know which var to decode
+                            def escapedKeys = escapeEncodedKeys(encodedKeys)
+                            variant.buildConfigField "String[]", "ENCODED_KEYS", escapedKeys
                         }
                     }
                 }

--- a/android/dotenv.gradle
+++ b/android/dotenv.gradle
@@ -66,12 +66,59 @@ def loadDotEnv(flavor = getCurrentFlavor()) {
 
 loadDotEnv()
 
+def keyLength = 64
+
+def generateKey(int keyLength = 64) {
+    return new Random().with {
+        (1..keyLength).collect {
+            (('a'..'z')).join()[ nextInt((('a'..'z')).join().length())]
+        }.join()
+    }
+}
+
+/**
+ * First uses a simple xor encryption on string using provided key
+ * The resulting byte array is further encoded as base64 encoded string
+ *
+ * To decode the returned string you'd have to first Base64.decode(encodedString),
+ * then xor decrypt the returned byte array (by applying this same xor encryption
+ *       because when you apply it twice, you get back the original string),
+ * then build a new string with the decrypted byte array: new String(resultBytes);
+ *
+ * @param str
+ * @param key
+ * @return
+ */
+def encodeString(String str, String key) {
+    int len = str.length()
+    int keyLen = key.length()
+
+    byte[] strBytes = str.getBytes()
+    byte[] keyBytes = key.getBytes()
+    byte[] result = new byte[len]
+
+    for (int i = 0; i < len; i++)
+    {
+        result[i] = (byte) (strBytes[i] ^ keyBytes[i % keyLen])
+    }
+
+    return result.encodeBase64().toString()
+}
+
+
 android {
     defaultConfig {
+        String xorKey = generateKey(keyLength)
         project.env.each { k, v ->
             def escaped = v.replaceAll("%","\\\\u0025")
-            buildConfigField "String", k, "\"$v\""
-            resValue "string", k, "\"$escaped\""
+            def encodedValue = encodeString(v, xorKey)
+            def encodedEscaped = encodeString(escaped, xorKey)
+
+            buildConfigField "String", k, "\"$encodedValue\""
+            buildConfigField "String", "XOR_KEY", "\"$xorKey\""
+
+            resValue "string", k, "\"$encodedEscaped\""
+            resValue "string", "XOR_KEY", "\"$xorKey\""
         }
     }
 }
@@ -85,10 +132,19 @@ tasks.whenTaskAdded { task ->
                         def variantConfigString = variant.getName()
                         if (envConfigName.contains(variantConfigString.toLowerCase())) {
                             loadDotEnv(envConfigName)
+
+                            String xorKey = generateKey(keyLength)
                             project.env.each { k, v ->
                                 def escaped = v.replaceAll("%","\\\\u0025")
-                                variant.buildConfigField "String", k, "\"$v\""
-                                variant.resValue "string", k, "\"$escaped\""
+                                def encodedValue = encodeString(v, xorKey)
+                                def encodedEscaped = encodeString(escaped, xorKey)
+
+
+                                variant.buildConfigField "String", k, "\"$encodedValue\""
+                                variant.buildConfigField "String", "XOR_KEY", "\"$xorKey\""
+
+                                variant.resValue "string", k, "\"$encodedEscaped\""
+                                variant.resValue "string", "XOR_KEY", "\"$xorKey\""
                             }
                         }
                     }

--- a/android/src/main/java/com/lugg/ReactNativeConfig/ReactNativeConfigModule.java
+++ b/android/src/main/java/com/lugg/ReactNativeConfig/ReactNativeConfigModule.java
@@ -79,18 +79,18 @@ public class ReactNativeConfigModule extends ReactContextBaseJavaModule {
   }
 
   private String decode(Object encodedString, String key) {
-        byte[] decodedBytes = Base64.decode((String) encodedString, Base64.DEFAULT);
-        byte[] keyBytes = key.getBytes();
+    byte[] decodedBytes = Base64.decode((String) encodedString, Base64.DEFAULT);
+    byte[] keyBytes = key.getBytes();
 
-        int len = decodedBytes.length;
-        int keyBytesLen = keyBytes.length;
+    int len = decodedBytes.length;
+    int keyBytesLen = keyBytes.length;
 
-        byte[] resultBytes = new byte[len];
+    byte[] resultBytes = new byte[len];
 
-        for (int i = 0; i < decodedBytes.length; i++) {
-            resultBytes[i] = (byte) (decodedBytes[i] ^ keyBytes[i % keyBytesLen]);
-        }
-
-        return new String(resultBytes);
+    for (int i = 0; i < decodedBytes.length; i++) {
+        resultBytes[i] = (byte) (decodedBytes[i] ^ keyBytes[i % keyBytesLen]);
     }
+
+    return new String(resultBytes);
+  }
 }

--- a/android/src/main/java/com/lugg/ReactNativeConfig/ReactNativeConfigModule.java
+++ b/android/src/main/java/com/lugg/ReactNativeConfig/ReactNativeConfigModule.java
@@ -3,6 +3,7 @@ package com.lugg.ReactNativeConfig;
 import android.content.Context;
 import android.content.res.Resources;
 import android.util.Log;
+import android.util.Base64;
 
 import com.facebook.react.bridge.ReactApplicationContext;
 import com.facebook.react.bridge.ReactContextBaseJavaModule;
@@ -10,6 +11,9 @@ import com.facebook.react.bridge.ReactContextBaseJavaModule;
 import java.lang.ClassNotFoundException;
 import java.lang.IllegalAccessException;
 import java.lang.reflect.Field;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
 import java.util.Map;
 import java.util.HashMap;
 
@@ -37,10 +41,30 @@ public class ReactNativeConfigModule extends ReactContextBaseJavaModule {
         className = getReactApplicationContext().getApplicationContext().getPackageName();
       }
       Class clazz = Class.forName(className + ".BuildConfig");
+
+      Field xorKeyField;
+      Field encodedKeysField;
+
+      String xorKey = null;
+      List<String> encodedKeys = new ArrayList<>();
+      try {
+        xorKeyField = clazz.getDeclaredField("XOR_KEY");
+        xorKey = (String) xorKeyField.get(null);
+        encodedKeysField = clazz.getDeclaredField("ENCODED_KEYS");
+        encodedKeys = Arrays.asList((String[]) encodedKeysField.get(new String[1]));
+      } catch(NoSuchFieldException | SecurityException | IllegalAccessException e) {
+        Log.d("ReactNative", "ReactConfig: Could not access XOR_KEY or ENCODED_KEYS");
+      }
+
       Field[] fields = clazz.getDeclaredFields();
       for(Field f: fields) {
         try {
-          constants.put(f.getName(), f.get(null));
+          Object value = f.get(null);
+          String name = f.getName();
+          if (xorKey != null && encodedKeys.contains(name)) {
+            value = decode(value, xorKey);
+          }
+          constants.put(name, value);
         }
         catch (IllegalAccessException e) {
           Log.d("ReactNative", "ReactConfig: Could not access BuildConfig field " + f.getName());
@@ -53,4 +77,20 @@ public class ReactNativeConfigModule extends ReactContextBaseJavaModule {
 
     return constants;
   }
+
+  private String decode(Object encodedString, String key) {
+        byte[] decodedBytes = Base64.decode((String) encodedString, Base64.DEFAULT);
+        byte[] keyBytes = key.getBytes();
+
+        int len = decodedBytes.length;
+        int keyBytesLen = keyBytes.length;
+
+        byte[] resultBytes = new byte[len];
+
+        for (int i = 0; i < decodedBytes.length; i++) {
+            resultBytes[i] = (byte) (decodedBytes[i] ^ keyBytes[i % keyBytesLen]);
+        }
+
+        return new String(resultBytes);
+    }
 }


### PR DESCRIPTION
This PR allows us to apply simple xor encryption and base64 encoding to env vars before they are injected into the BuildConfig by react-native-config during build time.
Before the xor encrypted vars are bridged to react native they are decrypted, so no decryption needs to be done in react native. 
However for env var use in the android java/kotlin native layer, the app needs to define a decryption method. Sample is available in `../Example/android/app/src/main/java/com/example/ReactNativeConfigUtils.java`
An array of encrypted vars can be found in BuildConfig.ENCODED_KEYS. An app trying to decrypt an env var may check if the env var's name is contained in its BuildConfig.ENCODED_KEYS before decrypting.

| Before | After |
| ---- | ---- |
![Screenshot_1621354519](https://user-images.githubusercontent.com/18648835/118689709-993b1500-b807-11eb-9842-380a7ecb40ea.png)|![Screenshot_1621354200](https://user-images.githubusercontent.com/18648835/118689844-b96ad400-b807-11eb-9b86-0cc68c00bf40.png)|

